### PR TITLE
FIX: make genfromtxt better

### DIFF
--- a/MatplotlibExample.ipynb
+++ b/MatplotlibExample.ipynb
@@ -270,6 +270,9 @@
   }
  ],
  "metadata": {
+  "jupytext": {
+   "formats": "ipynb,md"
+  },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",

--- a/MatplotlibExample.md
+++ b/MatplotlibExample.md
@@ -1,0 +1,134 @@
+---
+jupyter:
+  jupytext:
+    formats: ipynb,md
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.13.0
+  kernelspec:
+    display_name: Python 3 (ipykernel)
+    language: python
+    name: python3
+---
+
+# Matplotlib interactive examples
+
+This is a small example of using Matplotlib for interactive data visualization. 
+
+To get interactive visualization you must "run" the notebook cells (in order).  You can hit the "play" triangle above, or the "play-all" double triangle to run all the cells, or select a cell and hit "Shift-Enter".  Once active, you can zoom and pan in the provided data using the GUI toolbar at left of each figure.
+
+```python
+import numpy as np
+import matplotlib.pyplot as plt
+
+# this sets up the Matplotlib interactive windows:
+%matplotlib widget
+
+# this changes the default date converter for better interactive plotting of dates:
+plt.rcParams['date.converter'] = 'concise'
+```
+
+## Time series example: temperature at Dinosaur, Co
+
+Data is from https://www.ncei.noaa.gov/pub/data/uscrn/products/hourly02/ and is hourly temperature and solar radiation at Dinosaur, Colorado.
+
+### Load the data
+
+```python
+#   Note the use of datetimes in the file complicate loading a bit.
+#   We recommend using pandas or xarray for more elegant solutions
+#   to handling complex timeseries data. 
+with open('data/small.txt', 'r') as f:
+    data = np.genfromtxt(f, dtype='datetime64[s],f,f,f', 
+                         names=['date', 'doy', 'temp', 'solar'])
+datetime = data['date']
+dayofyear = data['doy']
+temperature = data['temp']
+solar = data['solar']
+
+# make two-day smoothed versions:
+temp_low = np.convolve(temperature, np.ones(48)/48, mode='same')
+solar_low = np.convolve(solar, np.ones(48)/48, mode='same')
+```
+
+### Plot timeseries
+
+Here we plot the time series, add labels, title, and a small annotation about where the data came from.  Using the toolbar on the left you can zoom in on the data to see, for instance, the day/night warming and cooling. You can also pan along the time series using the icon with four arrows.  Note that because we have said `sharex=True` when creating the axes, the time window remains connected in both time seroes.
+
+```python
+fig, (ax0, ax1) = plt.subplots(2, 1, sharex=True, constrained_layout=True)
+
+# temperature:
+ax0.plot(datetime, temperature, label='hourly')
+ax0.plot(datetime, temp_low, label='smoothed')
+ax0.legend(loc='upper right')
+ax0.set_ylabel('Temperature $[^oC]$')  # note the use of TeX math formatting
+
+# solar-radiation:
+ax1.plot(datetime, solar, label='hourly')
+ax1.plot(datetime, solar_low, label='smoothed')
+ax1.legend(loc='upper right')
+ax1.set_ylabel('Solar radiation $[W\,m^{-2}]$')   # note the use of TeX math formatting
+
+ax0.set_title('Observations: Dinosaur, Colorado', loc='left')
+ax0.text(0.03, 0.03, 'https://www.ncei.noaa.gov/pub/data/uscrn/products/hourly02/', 
+         fontsize='small', fontstyle='italic', transform=ax0.transAxes);
+```
+
+### Plot property-versus-property
+
+Lets make a scatter plot of solar radiation versus temperature, colored by day of the year.  Note that we do not share the axes this time because the dynamic range of the hourly and smoothed data is different.
+
+```python
+fig, [ax0, ax1] = plt.subplots(1, 2, constrained_layout=True, figsize=(8, 4))
+
+ax0.set_facecolor('0.6')
+sc = ax0.scatter(solar, temperature, c=dayofyear, s=2, cmap='RdBu_r')
+ax0.set_xlabel('Solar Radiation $[W\,m^{-2}]$')
+ax0.set_ylabel('Temperature $[^oC]$')
+ax0.set_title('Hourly', loc='left')
+
+
+ax1.set_facecolor('0.6')
+sc = ax1.scatter(solar_low[::24], temp_low[::24], c=dayofyear[::24], s=4, cmap='RdBu_r')
+ax1.set_xlabel('Solar Radiation $[W\,m^{-2}]$')
+ax1.set_ylabel('Temperature $[^oC]$')
+ax1.set_title('Smoothed', loc='left')
+
+fig.colorbar(sc, ax=[ax0, ax1], shrink=0.6, label='day of year')
+```
+
+## Image data: global land-surface temperature
+
+Matplotlib can also plot two-dimensional data as in this example of land surface temperature.  Note that for geographic data a package like cartopy or metpy is recommended.  
+
+### Load the data
+
+```python
+dat = np.genfromtxt('data/MOD_LSTD_E_2021-08-29_gs_720x360.CSV', delimiter=',')
+dat = np.where(dat<1000, dat, np.NaN)
+dat = dat[::-1, :]
+lon = np.arange(-180.0, 180.1, 0.5)
+lat = np.arange(-90.0, 90.1, 0.5)
+date = '2021-08-29 to 2021-09-05'
+source = 'https://neo.sci.gsfc.nasa.gov/view.php?datasetId=MOD_LSTD_E&date=2021-09-01'
+```
+
+### Plot data
+
+```python
+fig, ax = plt.subplots(constrained_layout=True, figsize=(7, 4))
+ax.set_facecolor('0.8')
+pc = ax.pcolormesh(lon, lat, dat, shading='auto', cmap='inferno')
+ax.set_aspect(1.3)
+ax.set_xlabel('Longitude $[^o E]$')
+ax.set_ylabel('Latitude $[^o N]$')
+fig.colorbar(pc, shrink=0.6, extend='both', label='land temperature $[^oC]$');
+ax.set_title(f'source: {source}', loc='left', fontsize='x-small');
+```
+
+```python
+
+```

--- a/_PreProcess.ipynb
+++ b/_PreProcess.ipynb
@@ -68,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 2,
    "id": "26404dbb",
    "metadata": {},
    "outputs": [
@@ -78,14 +78,14 @@
        "Text(0.5, 1.0, 'Dinosaur, Colorado')"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "489f1a87d14c46eda1d85b3a79fadc64",
+       "model_id": "b2d02da8fdd146808b5606ca05308db9",
        "version_major": 2,
        "version_minor": 0
       },
@@ -140,7 +140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 3,
    "id": "14043e75-6808-4b20-b817-e8f5de887deb",
    "metadata": {},
    "outputs": [
@@ -156,17 +156,17 @@
     {
      "data": {
       "text/plain": [
-       "[<matplotlib.lines.Line2D at 0x130709160>]"
+       "[<matplotlib.lines.Line2D at 0x18947bca0>]"
       ]
      },
-     "execution_count": 50,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "428ae0720c2442568d8c41d59005a965",
+       "model_id": "15167a2550384f5db6c34352a1500e26",
        "version_major": 2,
        "version_minor": 0
       },
@@ -200,7 +200,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 4,
    "id": "b85880f8-9d99-43e2-a17f-d7cd0850a787",
    "metadata": {},
    "outputs": [],
@@ -215,20 +215,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "id": "daa12c24-eeac-4657-9530-1e5fbcd82b20",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CRNH0203-2018-CO_Dinosaur_2_E.txt all.txt\n",
-      "CRNH0203-2019-CO_Dinosaur_2_E.txt small.txt\n",
-      "CRNH0203-2020-CO_Dinosaur_2_E.txt\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": []
   },
   {
@@ -243,7 +233,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 5,
    "id": "27986c69-5df6-48f8-a309-64a1a9ffce0d",
    "metadata": {},
    "outputs": [],
@@ -253,7 +243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "id": "b818784e-4769-4f0c-93fd-63ff1d38323b",
    "metadata": {},
    "outputs": [],
@@ -267,7 +257,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 7,
    "id": "df2f48a4-fc21-48cd-8ceb-076fb51020be",
    "metadata": {},
    "outputs": [
@@ -275,24 +265,24 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/var/folders/vy/zxjl84j90ws6d1k09_rhst0w0000gp/T/ipykernel_42405/3708665128.py:4: MatplotlibDeprecationWarning: shading='flat' when X and Y have the same dimensions as C is deprecated since 3.3.  Either specify the corners of the quadrilaterals with X and Y, or pass shading='auto', 'nearest' or 'gouraud', or set rcParams['pcolor.shading'].  This will become an error two minor releases later.\n",
+      "/var/folders/vy/zxjl84j90ws6d1k09_rhst0w0000gp/T/ipykernel_61351/1084180396.py:2: MatplotlibDeprecationWarning: shading='flat' when X and Y have the same dimensions as C is deprecated since 3.3.  Either specify the corners of the quadrilaterals with X and Y, or pass shading='auto', 'nearest' or 'gouraud', or set rcParams['pcolor.shading'].  This will become an error two minor releases later.\n",
       "  ax.pcolormesh(lon, lat, dat)\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.QuadMesh at 0x1349f39a0>"
+       "<matplotlib.collections.QuadMesh at 0x18949ed60>"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c44373028ee440199d202e48c67496d0",
+       "model_id": "036afc53c7854ee0ac3a49885a1f30b3",
        "version_major": 2,
        "version_minor": 0
       },
@@ -329,6 +319,9 @@
   }
  ],
  "metadata": {
+  "jupytext": {
+   "formats": "ipynb,md"
+  },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",

--- a/_PreProcess.md
+++ b/_PreProcess.md
@@ -1,0 +1,152 @@
+---
+jupyter:
+  jupytext:
+    formats: ipynb,md
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.13.0
+  kernelspec:
+    display_name: Python 3 (ipykernel)
+    language: python
+    name: python3
+---
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+%matplotlib widget
+plt.rcParams['date.converter'] = 'concise'
+
+```
+
+<!-- #region -->
+## Data source:
+https://www.ncei.noaa.gov/pub/data/uscrn/products/hourly02/
+
+
+```
+Field#  Name                           Units
+---------------------------------------------
+   1    WBANNO                         XXXXX
+   2    UTC_DATE                       YYYYMMDD
+   3    UTC_TIME                       HHmm
+   4    LST_DATE                       YYYYMMDD
+   5    LST_TIME                       HHmm
+   6    CRX_VN                         XXXXXX
+   7    LONGITUDE                      Decimal_degrees
+   8    LATITUDE                       Decimal_degrees
+   9    T_CALC                         Celsius
+   10   T_HR_AVG                       Celsius
+   11   T_MAX                          Celsius
+   12   T_MIN                          Celsius
+   13   P_CALC                         mm
+   14   SOLARAD                        W/m^2
+   15   SOLARAD_FLAG                   X
+   16   SOLARAD_MAX                    W/m^2
+   17   SOLARAD_MAX_FLAG               X
+   18   SOLARAD_MIN                    W/m^2
+   19   SOLARAD_MIN_FLAG               X
+   20   SUR_TEMP_TYPE                  X
+   21   SUR_TEMP                       Celsius
+   22   SUR_TEMP_FLAG                  X
+   23   SUR_TEMP_MAX                   Celsius
+   24   SUR_TEMP_MAX_FLAG              X
+   25   SUR_TEMP_MIN                   Celsius
+   26   SUR_TEMP_MIN_FLAG              X
+   27   RH_HR_AVG                      %
+   28   RH_HR_AVG_FLAG                 X
+   29   SOIL_MOISTURE_5                m^3/m^3
+   30   SOIL_MOISTURE_10               m^3/m^3
+   31   SOIL_MOISTURE_20               m^3/m^3
+   32   SOIL_MOISTURE_50               m^3/m^3
+   33   SOIL_MOISTURE_100              m^3/m^3
+   34   SOIL_TEMP_5                    Celsius
+   35   SOIL_TEMP_10                   Celsius
+   36   SOIL_TEMP_20                   Celsius
+   37   SOIL_TEMP_50                   Celsius
+   38   SOIL_TEMP_100                  Celsius
+ ```
+<!-- #endregion -->
+
+```python
+data = np.genfromtxt('data/all.txt')
+date = data[:, 1]
+time = data[:, 2]
+datetime = []
+for d, t in zip(date, time):
+    st = f'{int(d):08d}T{int(t):04d}'
+    st = st[:-2] + ':' + st[-2:]
+    st = st[:4] + '-' + st[4:6] + '-' + st[6:]
+    datetime += [np.datetime64(st)] 
+datetime = np.asarray(datetime)
+temp = data[:, 9]
+temperature = np.where(temp>-1000, temp, np.NaN)
+
+solar = data[:, 13]
+solar = np.where(solar>-1000, solar, np.NaN)
+
+
+fig, (ax0, ax1) = plt.subplots(2, 1, sharex=True, constrained_layout=True)
+ax0.plot(datetime, temperature)
+
+ax0.set_ylabel('$Temperature [^oC]$')
+
+ax1.plot(datetime, solar)
+
+ax1.set_ylabel('Solar Radiation $[W\,m^{-1}]$')
+
+ax0.set_title('Dinosaur, Colorado')
+
+
+```
+
+```python
+# Make day of the year
+days = (datetime - np.datetime64('2018-01-01', 'D')).astype(np.float64) / 60 / 24
+print(days.dtype)
+print(days)
+days = np.mod(days, 365)
+fig, ax = plt.subplots()
+ax.plot(datetime, days)
+```
+
+```python
+with open('data/small.txt', 'w') as fout:
+    fout.write('# Extracted from CRNH0203-2018-CO_Dinosaur_2_E.txt from https://www.ncei.noaa.gov/pub/data/uscrn/products/hourly02/ \n')
+    fout.write('# datetime / day of year / temperature [deg C] / solar radiation [W/m^2] \n')
+
+    for date, d, t, s in zip(datetime, days, temperature, solar):
+        fout.write(f'{date} {d:8.3f} {t:6.1f} {s:9.1f}\n')
+```
+
+```python
+
+```
+
+## preprocess image data
+
+https://neo.sci.gsfc.nasa.gov/view.php?datasetId=MOD_LSTD_E&date=2021-09-01
+
+```python
+a = 10
+```
+
+```python
+dat = np.genfromtxt('data/MOD_LSTD_E_2021-08-29_gs_720x360.CSV', delimiter=',')
+dat = np.where(dat<1000, dat, np.NaN)
+dat = dat[::-1, :]
+lon = np.arange(0, 360, 0.5)
+lat = np.arange(-90, 90, 0.5)
+
+```
+
+```python
+fig, ax = plt.subplots()
+ax.pcolormesh(lon, lat, dat)
+```
+
+```python
+
+```

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,11 @@
+name: mpl_brochure_binder
+channels:
+  - conda-forge
+  - default
+dependencies:
+  - jupytext
+  - jupyterlab
+  - python
+  - numpy
+  - matplotlib
+  - ipympl

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-numpy
-matplotlib
-ipympl


### PR DESCRIPTION
Closes #3 by changing to 

```python
with open('data/small.txt', 'r') as f:
    data = np.genfromtxt(f, dtype='datetime64[s],f,f,f', 
                         names=['date', 'doy', 'temp', 'solar'])
datetime = data['date']
dayofyear = data['doy']
temperature = data['temp']
solar = data['solar']
```

probably could just work out of the structure, but this is perhaps less mystifying.  
