### PR TITLE
use matplotlib-base for lighter environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,5 +7,5 @@ dependencies:
   - jupyterlab
   - python
   - numpy
-  - matplotlib
+  - matplotlib-base
   - ipympl


### PR DESCRIPTION
The matplotlib conda package depends on qt and friends. For matplotlib on Binder, it's a bit more efficient to use `matplotlib-base` which is just the Python package and its actual strict dependencies.